### PR TITLE
Do not require CGO

### DIFF
--- a/plugin/channel.go
+++ b/plugin/channel.go
@@ -1,6 +1,5 @@
 package plugin
 
-import "C"
 import (
 	"bytes"
 	"fmt"


### PR DESCRIPTION
Picked from #20 in case you want have this separately.
Allows build with `CGO_ENABLED=0`