### PR TITLE
Handle array length 0 in ReadUInt8

### DIFF
--- a/core/io.go
+++ b/core/io.go
@@ -29,6 +29,9 @@ func ReadByte(r io.Reader) (byte, error) {
 
 func ReadUInt8(r io.Reader) (uint8, error) {
 	b, err := ReadBytes(1, r)
+	if len(b) == 0 {
+		return 0, err
+	}
 	return uint8(b[0]), err
 }
 


### PR DESCRIPTION
This looks to be randomly crashing when connecting legacy Windows Server 2008 R2 to error like this (I'm using my custom version with #26 but same issue is on code in here):
```
panic: runtime error: index out of range [0] with length 0

goroutine 2204 [running]:
github.com/tomatome/grdp/core.ReadUInt8(...)
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/core/io.go:32
github.com/tomatome/grdp/protocol/pdu.(*FastPathOrdersPDU).Unpack(0xc000024840, {0x11e5220, 0xc00024f620})
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/protocol/pdu/orders.go:162 +0x24b
github.com/tomatome/grdp/protocol/pdu.readFastPathUpdatePDU({0x11e5220, 0xc00024f620}, 0x0)
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/protocol/pdu/data.go:911 +0x11b
github.com/tomatome/grdp/protocol/pdu.(*Client).RecvFastPath(0xc00010f6e0, 0x0?, {0xc00007c000, 0x1d96, 0x1d96})
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/protocol/pdu/pdu.go:428 +0x58f
github.com/tomatome/grdp/protocol/sec.(*Client).RecvFastPath(0xc000186300?, 0x2?, {0xc0001da000?, 0xc0001dab65?, 0xc0000f4ba0?})
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/protocol/sec/sec.go:875 +0x6e
github.com/tomatome/grdp/protocol/tpkt.(*TPKT).recvFastPath(0xc000186240, {0xc0001da000, 0x1d9e, 0x1d9e}, {0x0, 0x0?})
	C:/Users/user/go/pkg/mod/github.com/olljanat/grdp@v0.0.0-20231109070701-045cbccd0693/protocol/tpkt/tpkt.go:227 +0x9b
github.com/tomatome/grdp/core.StartReadBytes.func1()
```